### PR TITLE
Fixed bug that caused `reported-job` option to not work

### DIFF
--- a/DbbenchTools/autopoc.py
+++ b/DbbenchTools/autopoc.py
@@ -96,7 +96,7 @@ def RunTest(args, param, level):
                 return []
 
         if args.reported_job:
-            ret = [qs for qs in data if qs.name == args.reported_job]
+            ret = [qs for qs in ret if qs.name == args.reported_job]
 
         matched_jobs = set(qs.name for qs in ret)
         if len(matched_jobs) == 0:


### PR DESCRIPTION
Running `$ dbbench-scaler --reported-job=foo --database=baz --concurrency=1 --output=/tmp/out.svg workload.ini` causes an `NameError: global name 'data' is not defined` error. This PR resolves this issue.